### PR TITLE
Fix sort tests

### DIFF
--- a/AspNetCore.Helpers/WebGrid/WebGridDataSource.cs
+++ b/AspNetCore.Helpers/WebGrid/WebGridDataSource.cs
@@ -62,7 +62,7 @@ namespace AndreyKurdiumov.AspNetCore.Helpers
                 // Force compile the underlying IQueryable
                 rowData = rowData.ToList();
             }
-            catch (ArgumentException)
+            catch (InvalidOperationException)
             {
                 // The OrderBy method uses a generic comparer which fails when the collection contains 2 or more 
                 // items that cannot be compared (e.g. DBNulls, mixed types such as strings and ints et al) with the exception


### PR DESCRIPTION
This change was required, since .NET Core now produce different exception when data has mixed data types. Before that .NET produce ArgumentException which comes from string.CompareTo method. Now this exception shielded by GenericArraySortHelper<T>.Sort and rethrown as InvalidOperationException